### PR TITLE
ribosomeProfilingQC 1.21.1 -- add GenomeInfoDbData to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ribosomeProfilingQC
 Type: Package
 Title: Ribosome Profiling Quality Control
-Version: 1.21.0
+Version: 1.21.1
 Authors@R: c(person(given="Jianhong", family="Ou", email="jou@morgridge.org", 
         role=c("aut", "cre"), comment=c(ORCID="0000-0002-8652-2488")),
         person(given="Mariah", family="Hoye", email="mariah.hoye@duke.edu",
@@ -27,4 +27,5 @@ Imports: AnnotationDbi, BiocGenerics, Biostrings, BSgenome, EDASeq,
          cluster, stats, graphics, grid, txdbmaker,
          ggExtra
 Suggests: RUnit, BiocStyle, knitr, BSgenome.Drerio.UCSC.danRer10, 
-          edgeR, DESeq2, limma, ashr, testthat, rmarkdown, vsn, Biobase
+          GenomeInfoDbData, edgeR, DESeq2, limma, ashr, testthat,
+          rmarkdown, vsn, Biobase

--- a/R/FLOSS.R
+++ b/R/FLOSS.R
@@ -32,7 +32,7 @@
 #' yieldSize <- 10000000
 #' bamfile <- BamFile(bamfilename, yieldSize = yieldSize)
 #' pc <- getPsiteCoordinates(bamfile, bestpsite=13)
-#' #library(GenomicFeatures)
+#' #library(txdbmaker)
 #' library(BSgenome.Drerio.UCSC.danRer10)
 #' #txdb <- makeTxDbFromGFF(system.file("extdata",
 #'  #         "Danio_rerio.GRCz10.91.chr1.gtf.gz",

--- a/R/assignReadingFrame.R
+++ b/R/assignReadingFrame.R
@@ -20,7 +20,7 @@
 #' bamfile <- BamFile(bamfilename, yieldSize = yieldSize)
 #' pc <- getPsiteCoordinates(bamfile, bestpsite=13)
 #' pc.sub <- pc[pc$qwidth %in% c(29, 30)]
-#' #library(GenomicFeatures)
+#' #library(txdbmaker)
 #' library(BSgenome.Drerio.UCSC.danRer10)
 #' #txdb <- makeTxDbFromGFF(system.file("extdata",
 #'  #         "Danio_rerio.GRCz10.91.chr1.gtf.gz",

--- a/R/estimatePsite.R
+++ b/R/estimatePsite.R
@@ -32,7 +32,7 @@
 #'                            package="ribosomeProfilingQC")
 #' yieldSize <- 10000000
 #' bamfile <- BamFile(bamfilename, yieldSize = yieldSize)
-#' #library(GenomicFeatures)
+#' #library(txdbmaker)
 #' library(BSgenome.Drerio.UCSC.danRer10)
 #' #txdb <- makeTxDbFromGFF(system.file("extdata",
 #'  #         "Danio_rerio.GRCz10.91.chr1.gtf.gz",

--- a/R/filterCDS.R
+++ b/R/filterCDS.R
@@ -8,7 +8,7 @@
 #' @import GenomicRanges
 #' @importFrom methods as is
 #' @examples
-#' #library(GenomicFeatures)
+#' #library(txdbmaker)
 #' library(BSgenome.Drerio.UCSC.danRer10)
 #' #txdb <- makeTxDbFromGFF(system.file("extdata",
 #'  #         "Danio_rerio.GRCz10.91.chr1.gtf.gz",

--- a/R/readsDistribution.R
+++ b/R/readsDistribution.R
@@ -30,7 +30,7 @@
 #' bamfile <- BamFile(bamfilename, yieldSize = yieldSize)
 #' pc <- getPsiteCoordinates(bamfile, bestpsite=11)
 #' pc.sub <- pc[pc$qwidth %in% c(29, 30)]
-#' library(GenomicFeatures)
+#' library(txdbmaker)
 #' library(BSgenome.Drerio.UCSC.danRer10)
 #' txdb <- makeTxDbFromGFF(system.file("extdata",
 #'           "Danio_rerio.GRCz10.91.chr1.gtf.gz",

--- a/R/readsEndPlot.R
+++ b/R/readsEndPlot.R
@@ -23,7 +23,7 @@
 #'                            package="ribosomeProfilingQC")
 #' yieldSize <- 10000000
 #' bamfile <- BamFile(bamfilename, yieldSize = yieldSize)
-#' #library(GenomicFeatures)
+#' #library(txdbmaker)
 #' library(BSgenome.Drerio.UCSC.danRer10)
 #' #txdb <- makeTxDbFromGFF(system.file("extdata",
 #'  #         "Danio_rerio.GRCz10.91.chr1.gtf.gz",

--- a/R/shiftReadsByFrame.R
+++ b/R/shiftReadsByFrame.R
@@ -14,7 +14,7 @@
 #' bamfile <- BamFile(bamfilename, yieldSize = yieldSize)
 #' pc <- getPsiteCoordinates(bamfile, bestpsite=11)
 #' pc.sub <- pc[pc$qwidth %in% c(29, 30)]
-#' library(GenomicFeatures)
+#' library(txdbmaker)
 #' library(BSgenome.Drerio.UCSC.danRer10)
 #' txdb <- makeTxDbFromGFF(system.file("extdata",
 #'           "Danio_rerio.GRCz10.91.chr1.gtf.gz",

--- a/R/strandPlot.R
+++ b/R/strandPlot.R
@@ -20,7 +20,7 @@
 #' bamfile <- BamFile(bamfilename, yieldSize = yieldSize)
 #' pc <- getPsiteCoordinates(bamfile, bestpsite=11)
 #' pc.sub <- pc[pc$qwidth %in% c(29, 30)]
-#' library(GenomicFeatures)
+#' library(txdbmaker)
 #' library(BSgenome.Drerio.UCSC.danRer10)
 #' txdb <- makeTxDbFromGFF(system.file("extdata",
 #'           "Danio_rerio.GRCz10.91.chr1.gtf.gz",

--- a/vignettes/ribosomeProfilingQC.Rmd
+++ b/vignettes/ribosomeProfilingQC.Rmd
@@ -24,7 +24,7 @@ output:
 suppressPackageStartupMessages({
   library(ribosomeProfilingQC)
   library(BSgenome.Drerio.UCSC.danRer10)
-  library(GenomicFeatures)
+  library(txdbmaker)
   library(Rsamtools)
   library(AnnotationDbi)
   library(motifStack)
@@ -78,14 +78,14 @@ First install _ribosomeProfilingQC_ and other packages required to run
 the examples.
 Please note that the example dataset used here is from zebrafish. 
 To run analysis with dataset from a different species or different assembly, 
-please install the corresponding Bsgenome and TxDb.
+please install the corresponding BSgenome and TxDb.
 For example, to analyze mouse data aligned to mm10, 
 please install BSgenome.Mmusculus.UCSC.mm10, 
 and TxDb.Mmusculus.UCSC.mm10.knownGene. 
 You can also generate a TxDb object by 
 functions `makeTxDbFromGFF` from a local gff file,
 or `makeTxDbFromUCSC`, `makeTxDbFromBiomart`, and `makeTxDbFromEnsembl`, 
-from online resources in _GenomicFeatures_ package.
+from online resources in _txdbmaker_ package.
 
 ```{r, eval=FALSE}
 library(BiocManager)
@@ -168,14 +168,14 @@ txdb <- TxDb.Mmusculus.UCSC.mm10.knownGene ## give it a short name
 CDS <- prepareCDS(txdb)
 ```
 
-You can also create a TxDb object from a gtf file by _GenomicFeatures::makeTxDbFromGFF_ function.
+You can also create a TxDb object from a gtf file by _txdbmaker::makeTxDbFromGFF_ function.
 To get GTF file, you can download it from [ensembl](http://useast.ensembl.org/info/data/ftp/index.html)
 or get the online file info via [_AnnotationHub_](#count-for-rpfs).
 Here we use a prepared TxDb object for testing.
 
 ```{r loadTxDb, class.source='vig'}
 ## Create a small TxDb object which only contain chr1 information.
-library(GenomicFeatures)
+library(txdbmaker)
 txdb <- makeTxDbFromGFF(system.file("extdata",
                                     "Danio_rerio.GRCz10.91.chr1.gtf.gz",
                                     package="ribosomeProfilingQC"),
@@ -859,7 +859,7 @@ danrer10.annotations <-
 
 ```{r, fig.width=4, fig.height=4, class.source='vig'}
 library(ribosomeProfilingQC)
-library(GenomicFeatures)
+library(txdbmaker)
 ## prepare CDS annotation
 txdb <- makeTxDbFromGFF(system.file("extdata",
                                     "Danio_rerio.GRCz10.91.chr1.gtf.gz",


### PR DESCRIPTION
Hi @jianhong,

It turns out that **ribosomeProfilingQC** needs a little fix in BioC 3.22 (the current devel version of Bioconductor) due to the following small change I made a couple of days ago to the **GenomeInfoDb** package: https://github.com/Bioconductor/GenomeInfoDb/commit/c4126c181c97a0914f52066c716958a08c797d81

Because of this change, **ribosomeProfilingQC** now fails to pass `R CMD check` on the [3.22 daily builds](https://bioconductor.org/checkResults/3.22/bioc-LATEST/ribosomeProfilingQC/nebbiolo2-checksrc.html), sorry. The reason for this failure is that the **ribosomeProfilingQC** package uses `txdbmaker::makeTxDbFromGFF()` in various places, which relies on the **GenomeInfoDbData** package.

This PR repairs that.

The fix is very simple: it just adds **GenomeInfoDbData** to `Suggests`. 

Also note that all the `makeTxDb*()` functions were moved from **GenomicFeatures** to **txdbmaker** about 1 year ago (in BioC 3.19), so `library(txdbmaker)` now needs to be used instead of `library(GenomicFeatures)` before calling `makeTxDbFromGFF()` in the vignette and examples. This PR also takes care of that.

Please let me know or ask on the bioc-devel mailing list if you have questions or concerns.

Thanks,
H.